### PR TITLE
stop representing block id in reverse order

### DIFF
--- a/src/ISL.hs
+++ b/src/ISL.hs
@@ -5,6 +5,7 @@ module ISL where
 
 import qualified Data.Map as Map
 import Data.Maybe
+import qualified Data.Vector.Generic as V
 import Types
 import Text.ParserCombinators.ReadP
 
@@ -52,8 +53,8 @@ lcut :: BlockId -> Orientation -> Offset -> Instruction
 lcut bid o off world = case world of
     World { canvas = cnvs, blocks  = tbl0, costs = tc } -> world { blocks = tbl3, costs = tc + c }
         where
-            b0@(bid0, block0) = (0:bid, SimpleBlock shp0 col)
-            b1@(bid1, block1) = (1:bid, SimpleBlock shp1 col)
+            b0@(bid0, block0) = (V.snoc bid 0, SimpleBlock shp0 col)
+            b1@(bid1, block1) = (V.snoc bid 1, SimpleBlock shp1 col)
             block = tbl0 Map.! bid
             col = blockColor block
             (x0,y0) = leftBottom (shape block)
@@ -95,10 +96,10 @@ pcut :: BlockId -> Point -> Instruction
 pcut bid (mx,my) world = case world of
     World { canvas = cnvs, blocks = tbl0, costs = tc } -> world { blocks = tbl2, costs = tc + c }
         where
-            b0@(bid0, block0) = (0:bid, SimpleBlock shp0 col)
-            b1@(bid1, block1) = (1:bid, SimpleBlock shp1 col)
-            b2@(bid2, block2) = (2:bid, SimpleBlock shp2 col)
-            b3@(bid3, block3) = (3:bid, SimpleBlock shp3 col)
+            b0@(bid0, block0) = (V.snoc bid 0, SimpleBlock shp0 col)
+            b1@(bid1, block1) = (V.snoc bid 1, SimpleBlock shp1 col)
+            b2@(bid2, block2) = (V.snoc bid 2, SimpleBlock shp2 col)
+            b3@(bid3, block3) = (V.snoc bid 3, SimpleBlock shp3 col)
             block = tbl0 Map.! bid
             col = blockColor block 
             (x0,y0) = leftBottom (shape block)
@@ -151,7 +152,7 @@ mergemove bid0 bid1 world = case world of
                 | x00 == x10 -> Rectangle (x00, min y00 y10) (x01, max y01 y11)
                 | y00 == y10 -> Rectangle (min x00 x10, y00) (max x01 x11, y01)
                 | otherwise  -> error "mergemove: not compatible shapes"
-            tbl1 = Map.insert [cnt] (ComplexBlock newshp [bid0, bid1]) tbl0
+            tbl1 = Map.insert (V.singleton cnt) (ComplexBlock newshp [bid0, bid1]) tbl0
             c0 = cost (size cnvs) 1 shp0
             c1 = cost (size cnvs) 1 shp1
             c  = max c0 c1

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -11,6 +11,7 @@ import Data.Aeson.TH
 import Data.Char
 import qualified Data.Map as Map
 import Data.List
+import qualified Data.Vector as V
 -- import qualified Data.Set as Set
 import qualified Graphics.Gloss as Gloss
 import qualified Graphics.Gloss.Data.Bitmap as Gloss
@@ -65,14 +66,13 @@ compatibleShape _ _ = False
 
 type Id = Int
 
--- Note that numbers are reversed
-type BlockId = [Int]
+type BlockId = V.Vector Int
 
 instance {-# Overlapping #-} Read BlockId where
     readsPrec _ = readP_to_S rBlockId
 
 rBlockId :: ReadP BlockId
-rBlockId = rBracket (reverse <$> sepBy1 rInt (char '.'))
+rBlockId = rBracket (V.fromList <$> sepBy1 rInt (char '.'))
 
 rInt :: ReadP Int
 rInt = read <$> many1 (satisfy isDigit)
@@ -165,7 +165,7 @@ dispMove = \case
                                           ]
 
 dispBlockId :: BlockId -> String
-dispBlockId = dispBetween "[" "]" . intercalate "." . map show . reverse
+dispBlockId = dispBetween "[" "]" . intercalate "." . map show . V.toList
 
 dispBetween :: String -> String -> String -> String
 dispBetween o c s = o ++ s ++ c
@@ -217,7 +217,7 @@ initializeWorld cvs is
     { canvas = cvs
     , prog = is
     , counter = 0
-    , blocks = Map.singleton [0] 
+    , blocks = Map.singleton (V.singleton 0)
                  (SimpleBlock (Rectangle (0,0) (400, 400)) white)
     , pict   = undefined
     , costs  = 0


### PR DESCRIPTION
ブロックIDが逆順になっているのは混乱するので、逆順にするのやめませんか?

変更が必要な箇所が型エラーになるように、ついでに型もリストから `Vector` に変更しています。